### PR TITLE
force redraw of canvas to reset issue from scaling

### DIFF
--- a/src/hooks/useAmbientCanvas.ts
+++ b/src/hooks/useAmbientCanvas.ts
@@ -12,11 +12,13 @@ export function useAmbientCanvas(
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
+    requestAnimationFrame(() => {
       canvas.width = 10;
       canvas.height = 6;
       // const rect = canvas.getBoundingClientRect();
       // canvas.width = rect.width;
       // canvas.height = rect.height;
+
       ctx.clearRect(0, 0, canvas.width, canvas.height);
 
       if (!imageUrl || !trigger) {
@@ -38,7 +40,12 @@ export function useAmbientCanvas(
         ctx.clearRect(0, 0, canvas.width, canvas.height);
         ctx.filter = "blur(2px)";
         ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        
+        canvas.style.transform = "translateZ(0.001px)";
+        requestAnimationFrame(() => {
+          canvas.style.transform = "";
+        });
       };
-
+    });
   }, [canvasRef, imageUrl, trigger]);
 }


### PR DESCRIPTION
There is an issue with canvases of small size that are scaled up on mobile and other devices
This PR hopes to address this by updating the drawing of the canvas after page load